### PR TITLE
Add index and node iterators

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,14 +130,17 @@ When the number of nodes in the tree represented as LOUDS is _N_:
 
 | Operation | Time-complexity | Space-complexity |
 |-----------|-----------------|------------------|
-| [Louds::from::<&str>()](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#implementations) | _O(N)_ | _N + o(N)_ |
-| [Louds::from::<&[bool]>()](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#implementations) | _O(N)_ | _N + o(N)_ |
-| [node_num_to_index()](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.node_num_to_index) | _O()_ | _N + o(N)_ |
-| [index_to_node_num()](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.index_to_node_num) | _O(1)_ | _O(1)_ |
-| [child_to_parent()](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.child_to_parent) | _O(1)_ | _O(1)_ |
-| [parent_to_children()](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O( max(log N, <u>max num of children a node has</u>) )_ | _O( max(log N, <u>max num of children a node has</u>) )_ |
+| [`Louds::from::<&str>()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#implementations) | _O(N)_ | _N + o(N)_ |
+| [`Louds::from::<&[bool]>()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#implementations) | _O(N)_ | _N + o(N)_ |
+| [`node_num_to_index()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.node_num_to_index) | _O()_ | _N + o(N)_ |
+| [`index_to_node_num()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.index_to_node_num) | _O(1)_ | _O(1)_ |
+| [`child_to_parent()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.child_to_parent) | _O(1)_ | _O(1)_ |
+| [`parent_to_children()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O( max(log N, <u>max num of children a node has</u>) )_ | _O( max(log N, <u>max num of children a node has</u>) )_ |
+| [`parent_to_children_indices()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O(log N)_ | _O( 1 )_ |
+| [`parent_to_children_indices().next()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O(1)_ | _O( 0 )_ |
+| [`parent_to_children_indices().next_back()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O(<u>max num of children a node has</u> )_ on first call _O(1)_ on next | _O( 0 )_ |
 
-(`node_num_to_index()` and `child_to_parent()` use [Fid::select()](https://laysakura.github.io/fid-rs/fid_rs/fid/struct.Fid.html#method.select). `index_to_node_num()` and `parent_to_children()` use [rank()](https://laysakura.github.io/fid-rs/fid_rs/fid/struct.Fid.html#method.rank)).
+(`node_num_to_index()` and `child_to_parent()` use [Fid::select()](https://laysakura.github.io/fid-rs/fid_rs/fid/struct.Fid.html#method.select). `index_to_node_num()` and `parent_to_children()` use [rank()](https://laysakura.github.io/fid-rs/fid_rs/fid/struct.Fid.html#method.rank)). `parent_to_children_nodes()` has the same time complexity as `parent_to_children_indices()`.
 
 ## Versions
 louds-rs uses [semantic versioning](http://semver.org/spec/v2.0.0.html).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,14 +128,17 @@
 //!
 //! | Operation | Time-complexity | Space-complexity |
 //! |-----------|-----------------|------------------|
-//! | [Louds::from::<&str>()](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#implementations) | _O(N)_ | _N + o(N)_ |
-//! | [Louds::from::<&[bool]>()](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#implementations) | _O(N)_ | _N + o(N)_ |
-//! | [node_num_to_index()](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.node_num_to_index) | _O()_ | _N + o(N)_ |
-//! | [index_to_node_num()](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.index_to_node_num) | _O(1)_ | _O(1)_ |
-//! | [child_to_parent()](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.child_to_parent) | _O(1)_ | _O(1)_ |
-//! | [parent_to_children()](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O( max(log N, <u>max num of children a node has</u>) )_ | _O( max(log N, <u>max num of children a node has</u>) )_ |
+//! | [`Louds::from::<&str>()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#implementations) | _O(N)_ | _N + o(N)_ |
+//! | [`Louds::from::<&[bool]>()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#implementations) | _O(N)_ | _N + o(N)_ |
+//! | [`node_num_to_index()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.node_num_to_index) | _O()_ | _N + o(N)_ |
+//! | [`index_to_node_num()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.index_to_node_num) | _O(1)_ | _O(1)_ |
+//! | [`child_to_parent()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.child_to_parent) | _O(1)_ | _O(1)_ |
+//! | [`parent_to_children()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O( max(log N, <u>max num of children a node has</u>) )_ | _O( max(log N, <u>max num of children a node has</u>) )_ |
+//! | [`parent_to_children_indices()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O(log N)_ | _O( 1 )_ |
+//! | [`parent_to_children_indices().next()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O(1)_ | _O( 0 )_ |
+//! | [`parent_to_children_indices().next_back()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O(<u>max num of children a node has</u> )_ on first call _O(1)_ on next | _O( 0 )_ |
 //!
-//! (`node_num_to_index()` and `child_to_parent()` use [Fid::select()](https://laysakura.github.io/fid-rs/fid_rs/fid/struct.Fid.html#method.select). `index_to_node_num()` and `parent_to_children()` use [rank()](https://laysakura.github.io/fid-rs/fid_rs/fid/struct.Fid.html#method.rank)).
+//! (`node_num_to_index()` and `child_to_parent()` use [Fid::select()](https://laysakura.github.io/fid-rs/fid_rs/fid/struct.Fid.html#method.select). `index_to_node_num()` and `parent_to_children()` use [rank()](https://laysakura.github.io/fid-rs/fid_rs/fid/struct.Fid.html#method.rank)). `parent_to_children_nodes()` has the same time complexity as `parent_to_children_indices()`.
 
 pub use louds::{Louds, LoudsIndex, LoudsNodeNum, ChildIndexIter, ChildNodeIter};
 pub mod louds;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,5 +137,5 @@
 //!
 //! (`node_num_to_index()` and `child_to_parent()` use [Fid::select()](https://laysakura.github.io/fid-rs/fid_rs/fid/struct.Fid.html#method.select). `index_to_node_num()` and `parent_to_children()` use [rank()](https://laysakura.github.io/fid-rs/fid_rs/fid/struct.Fid.html#method.rank)).
 
-pub use louds::{Louds, LoudsIndex, LoudsNodeNum};
+pub use louds::{Louds, LoudsIndex, LoudsNodeNum, ChildIndexIter, ChildNodeIter};
 pub mod louds;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,5 +140,5 @@
 //!
 //! (`node_num_to_index()` and `child_to_parent()` use [Fid::select()](https://laysakura.github.io/fid-rs/fid_rs/fid/struct.Fid.html#method.select). `index_to_node_num()` and `parent_to_children()` use [rank()](https://laysakura.github.io/fid-rs/fid_rs/fid/struct.Fid.html#method.rank)). `parent_to_children_nodes()` has the same time complexity as `parent_to_children_indices()`.
 
-pub use louds::{Louds, LoudsIndex, LoudsNodeNum, ChildIndexIter, ChildNodeIter};
+pub use louds::{ChildIndexIter, ChildNodeIter, Louds, LoudsIndex, LoudsNodeNum};
 pub mod louds;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,9 +134,9 @@
 //! | [`index_to_node_num()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.index_to_node_num) | _O(1)_ | _O(1)_ |
 //! | [`child_to_parent()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.child_to_parent) | _O(1)_ | _O(1)_ |
 //! | [`parent_to_children()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O( max(log N, <u>max num of children a node has</u>) )_ | _O( max(log N, <u>max num of children a node has</u>) )_ |
-//! | [`parent_to_children_indices()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O(log N)_ | _O( 1 )_ |
-//! | [`parent_to_children_indices().next()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O(1)_ | _O( 0 )_ |
-//! | [`parent_to_children_indices().next_back()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O(<u>max num of children a node has</u> )_ on first call _O(1)_ on next | _O( 0 )_ |
+//! | [`parent_to_children_indices()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O(1)_ | _O( 1 )_ |
+//! | [`parent_to_children_indices().next()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O(log N)_ at first then _O(1)_ | _O( 0 )_ |
+//! | [`parent_to_children_indices().next_back()`](https://laysakura.github.io/louds-rs/louds_rs/louds/struct.Louds.html#method.parent_to_children) | _O(log N)_ at first then _O(1)_ | _O( 0 )_ |
 //!
 //! (`node_num_to_index()` and `child_to_parent()` use [Fid::select()](https://laysakura.github.io/fid-rs/fid_rs/fid/struct.Fid.html#method.select). `index_to_node_num()` and `parent_to_children()` use [rank()](https://laysakura.github.io/fid-rs/fid_rs/fid/struct.Fid.html#method.rank)). `parent_to_children_nodes()` has the same time complexity as `parent_to_children_indices()`.
 

--- a/src/louds.rs
+++ b/src/louds.rs
@@ -20,3 +20,6 @@ pub struct LoudsNodeNum(pub u64);
 #[derive(PartialEq, Eq, Debug, Clone, Copy)]
 /// Index of [Louds](struct.Louds.html) tree.
 pub struct LoudsIndex(pub u64);
+
+pub struct ChildIndexIter<'a> { inner: &'a Louds, index: u64 }
+pub struct ChildNodeIter<'a> { inner: &'a Louds, index: u64 }

--- a/src/louds.rs
+++ b/src/louds.rs
@@ -21,5 +21,7 @@ pub struct LoudsNodeNum(pub u64);
 /// Index of [Louds](struct.Louds.html) tree.
 pub struct LoudsIndex(pub u64);
 
-pub struct ChildIndexIter<'a> { inner: &'a Louds, index: u64 }
-pub struct ChildNodeIter<'a> { inner: &'a Louds, index: u64 }
+/// An index iterator.
+pub struct ChildIndexIter<'a> { inner: &'a Louds, index: u64, end: Option<u64> }
+/// A node iterator.
+pub struct ChildNodeIter<'a>(ChildIndexIter<'a>);

--- a/src/louds.rs
+++ b/src/louds.rs
@@ -24,7 +24,8 @@ pub struct LoudsIndex(pub u64);
 /// An index iterator.
 pub struct ChildIndexIter<'a> {
     inner: &'a Louds,
-    index: u64,
+    node: LoudsNodeNum,
+    start: Option<u64>,
     end: Option<u64>,
 }
 /// A node iterator.

--- a/src/louds.rs
+++ b/src/louds.rs
@@ -22,6 +22,10 @@ pub struct LoudsNodeNum(pub u64);
 pub struct LoudsIndex(pub u64);
 
 /// An index iterator.
-pub struct ChildIndexIter<'a> { inner: &'a Louds, index: u64, end: Option<u64> }
+pub struct ChildIndexIter<'a> {
+    inner: &'a Louds,
+    index: u64,
+    end: Option<u64>,
+}
 /// A node iterator.
 pub struct ChildNodeIter<'a>(ChildIndexIter<'a>);

--- a/src/louds/louds.rs
+++ b/src/louds/louds.rs
@@ -93,10 +93,6 @@ impl Louds {
             "NodeNum({}) does not exist in this LOUDS",
             node_num.0,
         )) + 1;
-        // let parent_end_index = self.lbs.select0(node_num.0 + 1).unwrap_or_else(|| panic!(
-        //     "NodeNum({}) does not exist in this LOUDS",
-        //     node_num.0 + 1,
-        // )) - 1;
         ChildIndexIter { inner: self, index: parent_start_index, end: None }
     }
 

--- a/src/louds/louds.rs
+++ b/src/louds/louds.rs
@@ -1,4 +1,4 @@
-use super::{Louds, LoudsIndex, LoudsNodeNum, ChildIndexIter, ChildNodeIter};
+use super::{ChildIndexIter, ChildNodeIter, Louds, LoudsIndex, LoudsNodeNum};
 use fid_rs::Fid;
 
 impl From<&str> for Louds {
@@ -51,10 +51,10 @@ impl Louds {
     pub fn node_num_to_index(&self, node_num: LoudsNodeNum) -> LoudsIndex {
         assert!(node_num.0 > 0);
 
-        let index = self.lbs.select(node_num.0).unwrap_or_else(|| panic!(
-            "NodeNum({}) does not exist in this LOUDS",
-            node_num.0,
-        ));
+        let index = self
+            .lbs
+            .select(node_num.0)
+            .unwrap_or_else(|| panic!("NodeNum({}) does not exist in this LOUDS", node_num.0,));
         LoudsIndex(index)
     }
 
@@ -89,11 +89,16 @@ impl Louds {
     pub fn parent_to_children_indices(&self, node_num: LoudsNodeNum) -> ChildIndexIter {
         assert!(node_num.0 > 0);
 
-        let parent_start_index = self.lbs.select0(node_num.0).unwrap_or_else(|| panic!(
-            "NodeNum({}) does not exist in this LOUDS",
-            node_num.0,
-        )) + 1;
-        ChildIndexIter { inner: self, index: parent_start_index, end: None }
+        let parent_start_index = self
+            .lbs
+            .select0(node_num.0)
+            .unwrap_or_else(|| panic!("NodeNum({}) does not exist in this LOUDS", node_num.0,))
+            + 1;
+        ChildIndexIter {
+            inner: self,
+            index: parent_start_index,
+            end: None,
+        }
     }
 
     /// # Panics
@@ -139,13 +144,15 @@ impl Louds {
 impl<'a> Iterator for ChildIndexIter<'a> {
     type Item = LoudsIndex;
     fn next(&mut self) -> Option<Self::Item> {
-        self.end.map(|last| self.index <= last)
-            .unwrap_or_else(||self.inner.lbs[self.index]).then(|| {
-        // self.inner.lbs[self.index].then(|| {
-            let result = LoudsIndex(self.index);
-            self.index += 1;
-            result
-        })
+        self.end
+            .map(|last| self.index <= last)
+            .unwrap_or_else(|| self.inner.lbs[self.index])
+            .then(|| {
+                // self.inner.lbs[self.index].then(|| {
+                let result = LoudsIndex(self.index);
+                self.index += 1;
+                result
+            })
     }
 }
 
@@ -168,13 +175,17 @@ impl<'a> DoubleEndedIterator for ChildIndexIter<'a> {
 impl<'a> Iterator for ChildNodeIter<'a> {
     type Item = LoudsNodeNum;
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().map(|index| self.0.inner.index_to_node_num(index))
+        self.0
+            .next()
+            .map(|index| self.0.inner.index_to_node_num(index))
     }
 }
 
 impl<'a> DoubleEndedIterator for ChildNodeIter<'a> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.0.next_back().map(|index| self.0.inner.index_to_node_num(index))
+        self.0
+            .next_back()
+            .map(|index| self.0.inner.index_to_node_num(index))
     }
 }
 
@@ -276,7 +287,6 @@ mod node_num_to_index_success_tests {
         t3_10: ("10_1110_10_0_1110_0_0_10_110_0_0_0", 10, 17),
         t3_11: ("10_1110_10_0_1110_0_0_10_110_0_0_0", 11, 18),
     }
-
 }
 
 #[cfg(test)]
@@ -345,7 +355,6 @@ mod index_to_node_num_success_tests {
         t3_10: ("10_1110_10_0_1110_0_0_10_110_0_0_0", 17, 10),
         t3_11: ("10_1110_10_0_1110_0_0_10_110_0_0_0", 18, 11),
     }
-
 }
 
 #[cfg(test)]
@@ -526,7 +535,6 @@ mod parent_to_children_success_tests {
         t3_10: ("10_1110_10_0_1110_0_0_10_110_0_0_0", 10, vec!()),
         t3_11: ("10_1110_10_0_1110_0_0_10_110_0_0_0", 11, vec!()),
     }
-
 }
 
 #[cfg(test)]
@@ -565,7 +573,6 @@ mod parent_to_children_indices_success_tests {
         t3_10: ("10_1110_10_0_1110_0_0_10_110_0_0_0", 10, vec!()),
         t3_11: ("10_1110_10_0_1110_0_0_10_110_0_0_0", 11, vec!()),
     }
-
 }
 
 #[cfg(test)]
@@ -604,7 +611,6 @@ mod parent_to_children_indices_rev_success_tests {
         t3_10: ("10_1110_10_0_1110_0_0_10_110_0_0_0", 10, vec!()),
         t3_11: ("10_1110_10_0_1110_0_0_10_110_0_0_0", 11, vec!()),
     }
-
 }
 
 #[cfg(test)]
@@ -652,7 +658,6 @@ mod parent_to_children_indices_next_back_success_tests {
         t3_10: ("10_1110_10_0_1110_0_0_10_110_0_0_0", 10, vec!()),
         t3_11: ("10_1110_10_0_1110_0_0_10_110_0_0_0", 11, vec!()),
     }
-
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Thank you very much for this library. I started using it by way of using [trie-rs](https://github.com/laysakura/trie-rs) and I wanted to be able to use iterators rather than collecting elements into a Vec. To that end I added an index and a node iterator. I noted their time complexity in the README and added tests.

One thing to note: The iterators implement `DoubleEndedIterator` but the first call is to `next_back()` is _O(children)_. We could push all the time complexity such that it wouldn't matter whether you called `next()` or `next_back()`. But I'm inclined to leave it as is with `next()` being the expected path, and `next_back()` being the exceptional path.

![Screenshot 2024-03-01 at 2 59 02 AM](https://github.com/laysakura/louds-rs/assets/54390/209e2453-f941-43ae-8370-0d63a5874cd7)
