### PR TITLE
Bumped version of mem-dbg and dependency fid-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["compression", "data-structures"]
 edition = "2018"
 
 [dependencies]
-fid-rs = "0.2.0"
+fid-rs = "0.2.1"
 serde = { version = "1.0", features = ["derive"], optional = true }
-mem_dbg = {version = "0.1.4", optional = true}
+mem_dbg = {version = "0.2.2", optional = true}
 
 [dev-dependencies]
 criterion = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "louds-rs"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Sho Nakatani <lay.sakura@gmail.com>"]
 description = "High performance LOUDS (Level-Order Unary Degree Sequence) library"
 readme = "README.md"


### PR DESCRIPTION
This PR is strictly dependant on [this other PR on fid-rs](https://github.com/laysakura/fid-rs/pull/27) being merged and the new crate being published. Do not merge this PR before the fid-rs PR is merged.